### PR TITLE
Update __init__.py

### DIFF
--- a/fix_yahoo_finance/__init__.py
+++ b/fix_yahoo_finance/__init__.py
@@ -233,10 +233,15 @@ class Ticker():
         data = _requests.get(url=url, params=params).json()
 
         # Getting data from json
-        error = data["chart"]["error"]
-        if error:
-            raise ValueError(self.ticker, error["description"])
-
+        try:
+            error = data["chart"]["error"]
+            if error:
+                print(ValueError(self.ticker, error["description"]))
+                return _pd.DataFrame()
+        except Exception as e:
+            print(e)
+            return _pd.DataFrame()
+         
         # quotes
         quotes = self._parse_quotes(data["chart"]["result"][0])
 


### PR DESCRIPTION
Some stocks have data on Bloomberg like "BF/B"， but when pilling data from this api (code like:   yf.download("BF/B", start="2019-01-21", end="2019-04-25",interval = "1d")), 
it would raise a error at original __init__.py : 236(error = data["chart"]["error"]    KeyError: 'chart'). So here you need to catch the error that may occur.
Maybe it's because the symbol is inconsistent , it is "BF-B" at Yahoo. 
if the symbol is "BF.B", it would raise at __init__.py : 238. But there ia a problem that if i was in main thread use (try:  yf.download("BF/B",start=...........      except Exception as e:pass)    , and the main thread can't catch the error that you raise at __init__.py : 238.
so i just add some (try ...catch..) to  aviod this error occur.